### PR TITLE
fix: Expose create_dictionary in module

### DIFF
--- a/regextypofix/__init__.py
+++ b/regextypofix/__init__.py
@@ -1,1 +1,1 @@
-from regextypofix.main import correct
+from regextypofix.main import correct, create_dictionary


### PR DESCRIPTION
Thank you for this module! It was very useful for building typo rules in order to see how they would behave.

This PR exposes the `create_dictionary()` function in the root of the module, without having to import `regextypofix.main`.

This also fixes the example used in the `Readme.rst` file; it attempts to import `create_dictionary()` directly, but it doesn't work because it's not exposed.